### PR TITLE
Fixes hanging connections problem

### DIFF
--- a/splunk/splunk.go
+++ b/splunk/splunk.go
@@ -158,6 +158,9 @@ func (c *Client) doRequest(b *bytes.Buffer) error {
 		return err
 	}
 
+	// need to make sure we close the body to avoid hanging the connection
+	defer res.Body.Close()
+
 	// If statusCode is not good, return error string
 	switch res.StatusCode {
 	case 200:


### PR DESCRIPTION
Upon success, the body of the response is not read nor closed. This makes the connection hang until it times out. If lots of messages are logged, this behavior makes the process run out of file descriptors. The fix is a simple res.Body.Close() deferred so it is executed on all paths.