### PR TITLE
Return typed HEC error responses

### DIFF
--- a/splunk/response.go
+++ b/splunk/response.go
@@ -1,0 +1,110 @@
+package splunk
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// EventCollectorResponse is the payload returned by the HTTP Event Collector
+// in response to requests.
+// https://docs.splunk.com/Documentation/Splunk/latest/RESTREF/RESTinput#services.2Fcollector
+type EventCollectorResponse struct {
+	Text               string     `json:"text"`
+	Code               StatusCode `json:"code"`
+	InvalidEventNumber *int       `json:"invalid-event-number"`
+	AckID              *int       `json:"ackId"`
+}
+
+var _ error = (*EventCollectorResponse)(nil)
+
+// Error implements the error interface.
+func (r *EventCollectorResponse) Error() string {
+	if r == nil {
+		return ""
+	}
+
+	var sb strings.Builder
+
+	sb.WriteString(r.Text + " (Code: " + strconv.Itoa(int(r.Code)))
+	if r.InvalidEventNumber != nil {
+		sb.WriteString(", InvalidEventNumber: " + strconv.Itoa(*r.InvalidEventNumber))
+	}
+	if r.AckID != nil {
+		sb.WriteString(", AckID: " + strconv.Itoa(*r.AckID))
+	}
+	sb.WriteRune(')')
+
+	return sb.String()
+}
+
+// StatusCode defines the meaning of responses returned by HTTP Event Collector
+// endpoints.
+type StatusCode int8
+
+const (
+	Success StatusCode = iota
+	TokenDisabled
+	TokenRequired
+	InvalidAuthz
+	InvalidToken
+	NoData
+	InvalidDataFormat
+	IncorrectIndex
+	InternalServerError
+	ServerBusy
+	DataChannelMissing
+	InvalidDataChannel
+	EventFieldRequired
+	EventFieldBlank
+	ACKDisabled
+	ErrorHandlingIndexedFields
+	QueryStringAuthzNotEnabled
+)
+
+// HTTPCode returns the HTTP code corresponding to the given StatusCode. It
+// returns -1 and an error in case the HTTP status code can not be determined.
+func (c StatusCode) HTTPCode() (code int, err error) {
+	switch c {
+	case Success:
+		code = http.StatusOK
+	case TokenDisabled:
+		code = http.StatusForbidden
+	case TokenRequired:
+		code = http.StatusUnauthorized
+	case InvalidAuthz:
+		code = http.StatusUnauthorized
+	case InvalidToken:
+		code = http.StatusForbidden
+	case NoData:
+		code = http.StatusBadRequest
+	case InvalidDataFormat:
+		code = http.StatusBadRequest
+	case IncorrectIndex:
+		code = http.StatusBadRequest
+	case InternalServerError:
+		code = http.StatusInternalServerError
+	case ServerBusy:
+		code = http.StatusServiceUnavailable
+	case DataChannelMissing:
+		code = http.StatusBadRequest
+	case InvalidDataChannel:
+		code = http.StatusBadRequest
+	case EventFieldRequired:
+		code = http.StatusBadRequest
+	case EventFieldBlank:
+		code = http.StatusBadRequest
+	case ACKDisabled:
+		code = http.StatusBadRequest
+	case ErrorHandlingIndexedFields:
+		code = http.StatusBadRequest
+	case QueryStringAuthzNotEnabled:
+		code = http.StatusBadRequest
+	default:
+		code = -1
+		err = fmt.Errorf("unknown status code %d", c)
+	}
+
+	return
+}

--- a/splunk/response_test.go
+++ b/splunk/response_test.go
@@ -1,0 +1,87 @@
+package splunk
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestEventCollectorResponseError(t *testing.T) {
+	invalidEventNumber := 2
+	ackID := 12345
+
+	testCases := []struct {
+		name   string
+		input  *EventCollectorResponse
+		expect string
+	}{
+		{
+			name:   "Response is nil",
+			input:  nil,
+			expect: "",
+		}, {
+			name: "All response attributes are set",
+			input: &EventCollectorResponse{
+				Text:               "An error",
+				Code:               10,
+				InvalidEventNumber: &invalidEventNumber,
+				AckID:              &ackID,
+			},
+			expect: "An error (Code: 10, InvalidEventNumber: 2, AckID: 12345)",
+		}, {
+			name: "Some response attributes are set",
+			input: &EventCollectorResponse{
+				Text:  "An error",
+				Code:  10,
+				AckID: &ackID,
+			},
+			expect: "An error (Code: 10, AckID: 12345)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			errStr := tc.input.Error()
+			if errStr != tc.expect {
+				t.Errorf("Expected %q, got %q", tc.expect, errStr)
+			}
+		})
+	}
+}
+
+func TestStatusCodeHTTPCode(t *testing.T) {
+	testCases := []struct {
+		name       string
+		input      StatusCode
+		expectCode int
+		expectErr  bool
+	}{
+		{
+			name:       "Known status code",
+			input:      IncorrectIndex,
+			expectCode: http.StatusBadRequest,
+			expectErr:  false,
+		}, {
+			name:       "Unknown status code",
+			input:      StatusCode(100),
+			expectCode: -1,
+			expectErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, err := tc.input.HTTPCode()
+
+			if !tc.expectErr && err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+			if tc.expectErr && err == nil {
+				t.Fatalf("Expected an error to occur")
+			}
+
+			if code != tc.expectCode {
+				t.Errorf("Expected %d, got %d", tc.expectCode, code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Thanks for this package! 🙌 We use it @triggermesh and have a use case for bubbling up the HTTP code returned by the HEC endpoint back to a message sender.

We tackled this by de-serializing the response body to a HEC response object (as documented at https://docs.splunk.com/Documentation/Splunk/latest/RESTREF/RESTinput#services.2Fcollector; you need to click "expand" near the POST method), and returning it as the error.

If the caller is interested in reading the contents of that response object, they can simply assert the value of the error as follows:
```golang
if hecResp, ok := err.(*splunk.EventCollectorResponse); ok  {
    // do something with hecResp
}
```

Additionally, one can determine the HTTP status code associated with a particular HEC status code as follows:
```golang
httpCode, err := hecResp.StatusCode.HTTPCode()
```