### PR TITLE
Add support for Go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ZachtimusPrime/Go-Splunk-HTTP
+
+go 1.14


### PR DESCRIPTION
There is no external dependency, so this is really all it takes to turn this package into a module. To benefit from this, the next release tag needs to follow semver, e.g. `v1.6.0` instead of `v1.6`.